### PR TITLE
Writing_Good_Commits: Remove the word "the"

### DIFF
--- a/Developers/Writing_Good_Commits.rst
+++ b/Developers/Writing_Good_Commits.rst
@@ -23,9 +23,9 @@ How to Write Good Commit Messages
 
 A commit message consists of 3 parts:
 
-- the shortlog
-- the commit body
-- the issue reference
+- shortlog
+- commit body
+- issue reference
 
 Example:
 


### PR DESCRIPTION
Remove "the" from lines 26-28 to improve readability.

Fixes https://github.com/coala-analyzer/documentation/issues/67