### PR TITLE
Codestyle.rst: Add line continuation policy

### DIFF
--- a/Developers/Codestyle.rst
+++ b/Developers/Codestyle.rst
@@ -63,3 +63,13 @@ with the allowed types:
 
 This will raise a ``TypeError`` if ``a``, ``b`` or ``c`` are not strings
 and ``c`` is not ``None``.
+
+Line Continuation
+~~~~~~~~~~~~~~~~~
+
+Since line continuation is not covered by PEP8 coding style guide you are supposed 
+to keep your multiple-line lists, dicts, tuples, function definitions, function calls,
+and any such structures either:
+
+- stay on one line
+- span multiple lines that list one parameter/item each


### PR DESCRIPTION
We are already enfocing it, but it's not covered by PEP8

Fixes https://github.com/coala-analyzer/documentation/issues/27